### PR TITLE
Fix audio not playing in chrome

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,6 +94,13 @@
 					transform: rotate(360deg);
 				}
 			}
+			#start {
+				position: fixed;
+				width: 100vw;
+				height: 100vh;
+				text-align: center;
+				background: black;
+			}
 		</style>
 	</head>
 
@@ -180,14 +187,13 @@
 
             ];
 
-			init();
-
 
 			var textElement;
             var moonContainer;
 			function init() {
+				document.getElementById("start").remove();
 				container = document.createElement( 'div' );
-				document.body.appendChild( container );
+				document.body.insertBefore( container, document.getElementById("loader") );
 
 				camera = new THREE.PerspectiveCamera( 45, window.innerWidth / window.innerHeight, 0.1, 1000 );
 				camera.position.set(40, 0, 0);
@@ -598,6 +604,7 @@
 			<h2 class="demoTekst" id="demoTekst">
 			</h2>
 		</div>
+		<div id="start"><button onclick="init()">Play demo!</button></div>
 
 	</body>
 </html>


### PR DESCRIPTION
Chrome has implemented a policy where audio will only play if it is preceded by a user interaction, so you shouldn't start the demo unless the user explicitly has clicked something. This also fixes another bug where the canvas gets explicitly inserted _before_ the loader and endscreen elements since they are supposed to appear in front of it - until now the canvas was only inserted first because none of the DOM has loaded just yet.